### PR TITLE
Simpler site deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,43 @@
-## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+
 os:
   - linux
   - osx
+
 julia:
   - 0.7
   - 1.0
+  - 1
   - nightly
+
 notifications:
   email: false
+
 git:
   depth: 99999999
-install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install lmodern texlive-luatex texlive-xetex texlive-latex-extra pgf; else brew cask install mactex-no-gui; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install ttf-ubuntu-font-family fonts-dejavu; else brew tap homebrew/cask-fonts; brew cask install font-ubuntu font-dejavu-sans; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install pdf2svg; else brew install pdf2svg; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install libgdbm3; else brew upgrade gdbm; fi
-  - if [ $TRAVIS_OS_NAME = osx ]; then export PATH=$PATH:/usr/local/texlive/2018/bin/x86_64-darwin; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install asciidoctor; else brew install asciidoctor; fi
-  - julia -e 'using Pkg; pkg"dev BinaryProvider"'
-#addons:
-#  apt_packages:
-#    - lmodern
-#    - fonts-dejavu
-#    - ttf-ubuntu-font-family
-#    - texlive-luatex
-#    - texlive-xetex
-#    - texlive-latex-extra
-#    - pgf
-#    - pdf2svg
-#    - libgdbm3
-#matrix:
-#  allow_failures:
-#  - julia: nightly
 
-after_success:
-  # generate documentation
-  #- mkdir ~/.fonts
-  #- cp ~/.julia/v0.6/ThinkJulia/fonts/* ~/.fonts
-  #- cp ~/.julia/v0.7/ThinkJulia/fonts/* ~/.fonts
-  #- luaotfload-tool --update
-  #- if [ $TRAVIS_OS_NAME = osx ]; then julia -e 'using ThinkJulia; cd(joinpath(splitdir(pathof(ThinkJulia))[1], "..", "book")); ARGS=("images","html","deploy"); include("make.jl")'; fi
+jobs:
+  allow_failures:
+    - julia: nightly
+  include:
+    - stage: deploy-site
+      julia: 1
+      os: linux
+      if: type != pull_request
+      script:
+        - julia --project -e 'using Pkg; pkg"build"'
+        - mkdir -p book/build
+        - julia --project=book -e 'using Pkg; pkg"dev ."; pkg"instantiate"'
+        - julia --project=book -e 'ARGS=["build", "images", "html"]; cd("book"); include("make.jl")'
+        - julia --project=book deploy.jl
+      addons:
+        apt_packages:
+          - asciidoctor
+          - texlive-luatex
+          - pdf2svg
+          - lmodern
+          - fonts-dejavu
+          - ttf-ubuntu-font-family
+          - texlive-xetex
+          - texlive-latex-extra
+          - pgf

--- a/book/make.jl
+++ b/book/make.jl
@@ -61,7 +61,7 @@ if "pdf" in ARGS
     title = "notes"
   end
   println("Run ASCIIDoctor")
-  run(`/Users/ben/Source/asciidoctor-htmlbook/exe/asciidoctor-htmlbook build/$(title).asciidoc`)
+  run(`asciidoctor-htmlbook build/$(title).asciidoc`)
   println("Cleanup equations")
   book = read("build/$(title).html", String)
   book = replace(book, "\\\\(\\("=> "\\(")

--- a/deploy.jl
+++ b/deploy.jl
@@ -1,0 +1,63 @@
+# Simple deploy
+
+# Version 1: simply build and deploy to gh-pages
+function deploy()
+  # Only push if on a build that is not a PR
+  pr = get(ENV, "TRAVIS_PULL_REQUEST", nothing)
+  if pr === nothing
+    @info "Local build. Not pushing"
+    return
+  elseif pr != "false"
+    @info "PR. Not pushing"
+    return
+  end
+
+  # Check that book/build exists
+  println(">> readdir")
+  println(readdir())
+  isdir("book/build") || error("Couldn't find build")
+
+  key = get(ENV, "GITHUB_AUTH", nothing)
+  if key === nothing
+    error("GITHUB_AUTH is required, create and add to Travis settings")
+  end
+
+  repo = ENV["TRAVIS_REPO_SLUG"]
+  user = split(repo, "/")[1]
+  upstream = "https://$user:$key@github.com/$repo"
+  run(`git remote add upstream $upstream`)
+  run(`git fetch --all`)
+  # Try to branch to gh-pages, creating it if it doesn't exist
+  if !success(`git checkout -f -b gh-pages upstream/gh-pages`)
+    run(`git checkout --orphan gh-pages`)
+    run(`git reset --hard`)
+    run(`git commit --allow-empty -m "Initial commit"`)
+  end
+
+  # This will create a folder for different branches, so more than one book is online
+  dst = ENV["TRAVIS_BRANCH"]
+  if dst == "master"
+    dst = "."
+  else
+    # Remove and recreate the folder
+    isdir(dst) && rm(dst, recursive=true)
+    mkpath(dst)
+  end
+
+  # Copy the build html and images folder to dst
+  mv("book/build/book.html", "$dst/index.html", force=true)
+  mv("book/build/images", "$dst/images", force=true)
+  rm("book/build", recursive=true)
+  run(`git add $dst`)
+  if !success(`git diff --cached --exit-code`) # Don't commit if there are no changes
+    run(`git commit -m ":robot: Building book in branch $dst"`)
+    run(`git push upstream gh-pages`)
+  end
+
+  pkg = split(repo, "/")[2]
+  site = "https://$user.github.io/$pkg/" * (dst == "." ? "" : "$dst/") * "index.html"
+  @info "Here is your site:"
+  @info "  \033[1;33m$site\033[0m"
+end
+
+deploy()


### PR DESCRIPTION
@christianpeel, I've created what I believe is a simpler deployment of the site. It allows multiple deployments, based on the branch, so this `deploy` branch built the site: https://cidamo.com.br/JuliaIntroBR.jl/deploy/index.html (cidamo.com.br because of the org redirection).
For it to work, the repository with the branch needs to have Travis CI configured and a `GITHUB_AUTH` environment variable.

In this PR I cleaned up `travis.yml`, created the `deploy.jl` file and make a small fix in `make.jl`.

This does not build the pdf.