### PR TITLE
Rename the Julia package from "ThinkJulia" to "JuliaIntroBR"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
-name = "ThinkJulia"
-uuid = "a7f2b756-c18b-4c7f-87da-faca9ac81b29"
+name = "JuliaIntroBR"
+uuid = "b51cafcc-e450-41f6-af11-4ef6aad3b1a0"
+version = "0.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/book/make.jl
+++ b/book/make.jl
@@ -1,4 +1,4 @@
-using ThinkJulia: makefigs, expandcodeblocks, deploybook
+using JuliaIntroBR: makefigs, expandcodeblocks, deploybook
 
 const root = dirname(@__FILE__)
 const src = joinpath(root, "src")
@@ -134,7 +134,7 @@ if "deploy" in ARGS
   end
   deploybook(
     root = root,
-    repo = "github.com/BenLauwens/ThinkJulia.jl",
+    repo = "github.com/JuliaIntro/JuliaIntroBR.jl",
     target = target,
     branch = "gh-pages",
     latest = "master",

--- a/book/src/chap03.asciidoc
+++ b/book/src/chap03.asciidoc
@@ -592,7 +592,7 @@ Escreva uma função denominada +alinhar_a_direita+ que recebe uma string denomi
 
 [source,@julia-eval chap03-ex]
 ----
-using ThinkJulia
+using JuliaIntroBR
 ----
 
 [source,@julia-repl chap03-ex]

--- a/book/src/chap04.asciidoc
+++ b/book/src/chap04.asciidoc
@@ -3,7 +3,7 @@
 
 Este capítulo apresenta um estudo de caso que demonstra o processo de design de funções que trabalham juntas.
 
-Ele introduz o turtle graphics, um jeito de criar desenhos por meio de um programa. O pacote turtle graphics não está incluso na biblioteca padrão do Julia, portanto o módulo ThinkJulia tem que ser adicionado na sua configuração do Julia.
+Ele introduz o turtle graphics, um jeito de criar desenhos por meio de um programa. O pacote turtle graphics não está incluso na biblioteca padrão do Julia, portanto o módulo JuliaIntroBR tem que ser adicionado na sua configuração do Julia.
 
 Os exemplos neste capítulo podem ser executados em um notebook gráfico no JuliaBox, que combina código, texto formatado, matemática e multimídia em um único documento (ver <<juliabox>>).
 (((JuliaBox, notebook gráfico)))
@@ -15,11 +15,11 @@ Um _módulo_ é um arquivo que contém uma coleção de funções relacionadas. 
 (((módulo)))(((pacote)))
 
 Pacotes podem ser instalados no REPL através do modo Pkg usando a tecla +]+.
-(((pass:[&#93;])))(((ThinkJulia)))((("módulo", "ThinkJulia", see="ThinkJulia")))
+(((pass:[&#93;])))(((JuliaIntroBR)))((("módulo", "JuliaIntroBR", see="JuliaIntroBR")))
 
 [source,jlcon]
 ----
-(v1.0) pkg> add https://github.com/BenLauwens/ThinkJulia.jl
+(v1.0) pkg> add https://github.com/JuliaIntro/JuliaIntroBR.jl
 ----
 
 Isso pode demorar um pouco.
@@ -29,17 +29,17 @@ Antes de podermos usar as funções de um módulo, temos que importá-lo usando 
 
 [source,@julia-repl-test]
 ----
-julia> using ThinkJulia
+julia> using JuliaIntroBR
 
 julia> 🐢 = Turtle()
 Luxor.Turtle(0.0, 0.0, true, 0.0, (0.0, 0.0, 0.0))
 ----
 
-O módulo +ThinkJulia+ possui uma função chamada +Turtle+ que cria um objeto +Luxor.Turtle+, que atribuímos a uma variável chamada +🐢+ (*+\:turtle: TAB+*).
+O módulo +JuliaIntroBR+ possui uma função chamada +Turtle+ que cria um objeto +Luxor.Turtle+, que atribuímos a uma variável chamada +🐢+ (*+\:turtle: TAB+*).
 (((Turtle)))((("tipo", "Luxor", "Turtle", see="Turtle")))
 
 Logo após criarmos a tartaruga, podemos chamar uma função que a move ao redor de um desenho. Por exemplo, para mover a tartaruga para a frente:
-(((para a frente)))((("função", "ThinkJulia", "para a frente", see="para a frente")))
+(((para a frente)))((("função", "JuliaIntroBR", "para a frente", see="para a frente")))
 
 [source,julia]
 ----
@@ -59,10 +59,10 @@ A palavra-chave +@svg+ executa uma macro que desenha uma imagem SVG. Macros são
 Os argumentos de +forward+ são a tartaruga e a distância em pixels, portanto o tamanho real do movimento depende do seu monitor.
 
 Outra função que nós podemos chamar com tartaruga como argumento é +turn+, para virar. O segundo argumento para +turn+ é o ângulo em graus.
-(((turn)))((("função", "ThinkJulia", "turn", see="turn")))
+(((turn)))((("função", "JuliaIntroBR", "turn", see="turn")))
 
 Além disso, cada tartaruga está segurando uma caneta, que pode estar tanto para baixo ou para cima; se a caneta está para baixo, a tartaruga deixa uma trilha quando ela se move. <<fig04-1>> mostra a trilha deixada pela tartaruga. As funções +penup+ e +pendown+ significam respectivamente “caneta para cima” e “caneta para baixo”.
-(((penup)))((("função", "ThinkJulia", "penup", see="penup")))(((pendown)))((("função", "ThinkJulia", "pendown", see="pendown")))
+(((penup)))((("função", "JuliaIntroBR", "penup", see="penup")))(((pendown)))((("função", "JuliaIntroBR", "pendown", see="pendown")))
 
 Para desenhar um ângulo reto, modifique a chamada de macro:
 

--- a/book/src/chap05.asciidoc
+++ b/book/src/chap05.asciidoc
@@ -600,7 +600,7 @@ recurse(3, 0)
 
 . Write a docstring that explains everything someone would need to know in order to use this function (and nothing else).
 
-The following exercises use the +ThinkJulia+ module, described in <<chap04>>:
+The following exercises use the +JuliaIntroBR+ module, described in <<chap04>>:
 
 [[ex05-5]]
 ===== Exercise 5-6

--- a/book/src/chap07.asciidoc
+++ b/book/src/chap07.asciidoc
@@ -405,7 +405,7 @@ To test it, write a function named +testsquareroot+ that prints a table like thi
 
 [source,@julia-eval]
 ----
-using ThinkJulia
+using JuliaIntroBR
 io = IOBuffer()
 testsquareroot(io)
 out = String(take!(io))

--- a/book/src/chap09.asciidoc
+++ b/book/src/chap09.asciidoc
@@ -6,7 +6,7 @@ This chapter presents the second case study, which involves solving word puzzles
 [[reading_word_lists]]
 === Reading Word Lists
 
-For the exercises in this chapter we need a list of English words. There are lots of word lists available on the Web, but the one most suitable for our purpose is one of the word lists collected and contributed to the public domain by Grady Ward as part of the Moby lexicon project (see https://wikipedia.org/wiki/Moby_Project). It is a list of 113809 official crosswords; that is, words that are considered valid in crossword puzzles and other word games. In the Moby collection, the filename is _113809of.fic_; you can download a copy, with the simpler name _words.txt_, from https://github.com/BenLauwens/ThinkJulia.jl/blob/master/data/words.txt.
+For the exercises in this chapter we need a list of English words. There are lots of word lists available on the Web, but the one most suitable for our purpose is one of the word lists collected and contributed to the public domain by Grady Ward as part of the Moby lexicon project (see https://wikipedia.org/wiki/Moby_Project). It is a list of 113809 official crosswords; that is, words that are considered valid in crossword puzzles and other word games. In the Moby collection, the filename is _113809of.fic_; you can download a copy, with the simpler name _words.txt_, from https://github.com/JuliaIntro/JuliaIntroBR.jl/blob/master/data/words.txt.
 (((Mobi lexicon)))
 
 This file is in plain text, so you can open it with a text editor, but you can also read it from Julia. The built-in function +open+ takes the name of the file as a parameter and returns a _file stream_ you can use to read the file.
@@ -14,8 +14,8 @@ This file is in plain text, so you can open it with a text editor, but you can a
 
 [source,@julia-eval chap09]
 ----
-using ThinkJulia
-fin = open(ThinkJulia.datapath("words.txt"));
+using JuliaIntroBR
+fin = open(JuliaIntroBR.datapath("words.txt"));
 ----
 
 [source,jlcon]

--- a/book/src/chap13.asciidoc
+++ b/book/src/chap13.asciidoc
@@ -94,7 +94,7 @@ your function should return +pass:['a']+ with probability latexmath:[\(\frac{2}{
 
 === Word Histogram
 
-You should attempt the previous exercises before you go on. You will also need https://github.com/BenLauwens/ThinkJulia.jl/blob/master/data/emma.txt.
+You should attempt the previous exercises before you go on. You will also need https://github.com/JuliaIntro/JuliaIntroBR.jl/blob/master/data/emma.txt.
 
 Here is a program that reads a file and builds a histogram of the words in the file:
 (((processfile)))((("function", "programmer-defined", "processfile", see="processfile")))(((processline)))((("function", "programmer-defined", "processline", see="processline")))

--- a/book/src/chap14.asciidoc
+++ b/book/src/chap14.asciidoc
@@ -250,15 +250,15 @@ The function +close+ will always be executed.
 A _database_ is a file that is organized for storing data. Many databases are organized like a dictionary in the sense that they map from keys to values. The biggest difference between a database and a dictionary is that the database is on disk (or other permanent storage), so it persists after the program ends.
 (((database)))
 
-ThinkJulia provides an interface to +GDBM+ (GNU dbm) for creating and updating database files. As an example, I’ll create a database that contains captions for image files.
+JuliaIntroBR provides an interface to +GDBM+ (GNU dbm) for creating and updating database files. As an example, I’ll create a database that contains captions for image files.
 (((GDBM)))
 
 Opening a database is similar to opening other files:
-(((DBM)))((("type", "ThinkJulia", "DBM", see="DBM")))
+(((DBM)))((("type", "JuliaIntroBR", "DBM", see="DBM")))
 
 [source,@julia-repl-test chap14]
 ----
-julia> using ThinkJulia
+julia> using JuliaIntroBR
 
 julia> db = DBM("captions", "c")
 DBM(<captions>)

--- a/book/src/chap18.asciidoc
+++ b/book/src/chap18.asciidoc
@@ -475,7 +475,7 @@ The previous chapters demonstrate a development plan we might call “type-orien
 But sometimes it is less obvious what objects you need and how they should interact. In that case you need a different development plan. In the same way that we discovered function interfaces by encapsulation and generalization, we can discover type interfaces by _data encapsulation_.
 (((data encapsulation)))
 
-Markov analysis, from <<markov_analysis>>, provides a good example. If you download my code from https://github.com/BenLauwens/ThinkJulia.jl/blob/master/src/solutions/chap13.jl, you’ll see that it uses two global variables—+suffixes+ and +prefix+—that are read and written from several functions.
+Markov analysis, from <<markov_analysis>>, provides a good example. If you download my code from https://github.com/JuliaIntro/JuliaIntroBR.jl/blob/master/src/solutions/chap13.jl, you’ll see that it uses two global variables—+suffixes+ and +prefix+—that are read and written from several functions.
 
 [source,@julia-setup]
 ----
@@ -533,7 +533,7 @@ This example suggests a development plan for designing types:
 
 ===== Exercise 18-3
 
-Download my Markov code from https://github.com/BenLauwens/ThinkJulia.jl/blob/master/src/solutions/chap13.jl, and follow the steps described above to encapsulate the global variables as attributes of a new struct called +Markov+.
+Download my Markov code from https://github.com/JuliaIntro/JuliaIntroBR.jl/blob/master/src/solutions/chap13.jl, and follow the steps described above to encapsulate the global variables as attributes of a new struct called +Markov+.
 
 
 === Glossary

--- a/book/src/chap19.asciidoc
+++ b/book/src/chap19.asciidoc
@@ -695,7 +695,7 @@ A dbm object has a field +handle+ of +Ptr{Cvoid}+ type. This field holds a C poi
 
 * the argument values: +handle+.
 
-The complete mapping of the GDBM library can be found as an example in the ThinkJulia sources.
+The complete mapping of the GDBM library can be found as an example in the JuliaIntroBR sources.
 
 === Glossary
 

--- a/book/src/colophon.asciidoc
+++ b/book/src/colophon.asciidoc
@@ -1,12 +1,9 @@
 [colophon]
 == Copyright
 
-Copyright © 2018 Allen Downey, Ben Lauwens. All rights reserved.
-
-_Think Julia_ is available under the Creative Commons Attribution-NonCommercial 3.0 Unported License. The authors maintain an online version at https://benlauwens.github.io/ThinkJulia.jl/latest/book.html
+This book is available under the Creative Commons Attribution-NonCommercial 3.0 Unported License. The authors maintain an online version at https://benlauwens.github.io/ThinkJulia.jl/latest/book.html
 
 *Ben Lauwens* is a Professor of Mathematics at Royal Military Academy (RMA Belgium). He has a PhD in Engineering and Master’s degrees from KU Leuven and RMA and Bachelor’s degree from RMA.
 
 *Allen Downey* is a Professor of Computer Science at Olin College of Engineering. He has taught at Wellesley College, Colby College and U.C. Berkeley. He has a PhD in Computer Science from U.C. Berkeley and Master’s and Bachelor’s degrees from MIT.
 
-A paper version of this book is published by O'Reilly Media: http://www.jdoqocy.com/click-9038105-11290546?url=http%3A%2F%2Fshop.oreilly.com%2Fproduct%2F0636920215707.do%3Fcmp%3Daf-strata-books-video-product_cj_0636920215707_%25zp&cjsku=0636920215707[http://shop.oreilly.com/product/0636920215707.do] and can be bought on Amazon: https://www.amazon.com/Think-Julia-Like-Computer-Scientist/dp/1492045039.

--- a/book/src/introduction.asciidoc
+++ b/book/src/introduction.asciidoc
@@ -67,9 +67,9 @@ This element indicates a warning or caution.
 
 === Using Code Examples
 
-All ((("code examples in this book")))((("Git")))((("GitHub")))((("repository")))((("online resources", "Julia")))code used in this book is available from a Git repository on GitHub: https://github.com/BenLauwens/ThinkJulia.jl. If you are not familiar with Git, it is a version control system that allows you to keep track of the files that make up a project. A collection of files under Git's control is called a “repository.” GitHub is a hosting service that provides storage for Git repositories and a convenient web interface.
+All ((("code examples in this book")))((("Git")))((("GitHub")))((("repository")))((("online resources", "Julia")))code used in this book is available from a Git repository on GitHub: https://github.com/JuliaIntro/JuliaIntroBR.jl. If you are not familiar with Git, it is a version control system that allows you to keep track of the files that make up a project. A collection of files under Git's control is called a “repository.” GitHub is a hosting service that provides storage for Git repositories and a convenient web interface.
 
-A ((("packages", "installing")))((("add command, in REPL")))convenience package is provided that can be directly added to Julia. Just type pass:[<code>add <a href="https://github.com/BenLauwens/ThinkJulia.jl">https://github.com/BenLauwens/ThinkJulia.jl</a></code>] in the REPL in Pkg mode, see <<turtles>>.
+A ((("packages", "installing")))((("add command, in REPL")))convenience package is provided that can be directly added to Julia. Just type pass:[<code>add <a https://github.com/JuliaIntro/JuliaIntroBR.jl">https://github.com/JuliaIntro/JuliaIntroBR.jl</a></code>] in the REPL in Pkg mode, see <<turtles>>.
 
 The ((("Julia", "running")))easiest way to run Julia code is by going to https://juliabox.com and starting a free session. Both the REPL and a notebook interface are available. If ((("Julia", "installing")))you want to have Julia locally installed on your computer, you can download https://juliacomputing.com/products/juliapro.html[JuliaPro] for free from Julia Computing. It consists of a recent Julia version, the Juno interactive development environment based on Atom, and a number of preinstalled Julia packages. If you are more adventurous, you can download Julia from https://julialang.org, install the editor you like (e.g., Atom or Visual Studio Code), and activate the plug-ins for Julia integration. To ((("IJulia package")))a local install, you can also add the +IJulia+ package and run a Jupyter notebook on your computer.
 
@@ -87,7 +87,7 @@ Thanks to all the students who worked with an early version of this book and all
 
 === Contributor List
 
-If you have a suggestion or correction, please send email to ben.lauwens@gmail.com or open an issue on https://github.com/BenLauwens/ThinkJulia.jl[GitHub]. If I make a change based on your feedback, I will add you to the contributor list (unless you ask to be omitted).
+If you have a suggestion or correction, please send email to ben.lauwens@gmail.com or open an issue on https://github.com/JuliaIntro/JuliaIntroBR.jl[GitHub]. If I make a change based on your feedback, I will add you to the contributor list (unless you ask to be omitted).
 
 Let me know what version of the book you are working with, and what format. If you include at least part of the sentence the error appears in, that will make it easy for me to search. Page and section numbers are fine, too, but not quite as easy to work with. Thanks!
 

--- a/book/src/preface.asciidoc
+++ b/book/src/preface.asciidoc
@@ -66,9 +66,9 @@ This element indicates a warning or caution.
 
 === Using Code Examples
 
-All code used in this book is available from a Git repository on GitHub: https://github.com/BenLauwens/ThinkJulia.jl. If you are not familiar with Git, it is a version control system that allows you to keep track of the files that make up a project. A collection of files under Git's control is called a “repository”. GitHub is a hosting service that provides storage for Git repositories and a convenient web interface.
+All code used in this book is available from a Git repository on GitHub: https://github.com/JuliaIntro/JuliaIntroBR.jl. If you are not familiar with Git, it is a version control system that allows you to keep track of the files that make up a project. A collection of files under Git's control is called a “repository”. GitHub is a hosting service that provides storage for Git repositories and a convenient web interface.
 
-A convenience package is provided that can be directly added to Julia. Just type *+pass:[add https://github.com/BenLauwens/ThinkJulia.jl]+* in the REPL in Pkg mode.
+A convenience package is provided that can be directly added to Julia. Just type *+pass:[add https://github.com/JuliaIntro/JuliaIntroBR.jl]+* in the REPL in Pkg mode.
 
 The easiest way to run Julia code is going to https://juliabox.com and start a free session. Both the REPL and a notebook interface are available. If you want to have Julia locally installed on you computer, JuliaPro from Julia Computing can be downloaded freely from https://juliacomputing.com/products/juliapro.html. It consists of a recent Julia version, the Juno IDE based on Atom and a number of preinstalled Julia packages. If you are more adventurous, you can download Julia from https://julialang.org, install the editor you like, e.g. Atom or Visual Studio Code, and activate the plugins for Julia integration. To a local install, you can also add the +IJulia+ package and run a Jupyter notebook on your computer.
 

--- a/src/JuliaIntroBR.jl
+++ b/src/JuliaIntroBR.jl
@@ -1,4 +1,4 @@
-module ThinkJulia
+module JuliaIntroBR
 
   __precompile__(false)
 
@@ -12,7 +12,7 @@ module ThinkJulia
 
   const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
   if !isfile(depsjl_path)
-      error("ThinkJulia not installed properly, run Pkg.build(\"ThinkJulia\"), restart Julia and try again")
+      error("JuliaIntroBR not installed properly, run Pkg.build(\"JuliaIntroBR\"), restart Julia and try again")
   end
   include(depsjl_path)
 


### PR DESCRIPTION
This PR renames the underlying Julia package from "ThinkJulia" to "JuliaIntroBR".   If you want to change this to "JuliaIntroPTBR" or something else that's fine and I can make the change (we'd also change the github repo name to match).  Unfortunately "JuliaIntroPT-BR" is not a valid name for a Julia module (or package).